### PR TITLE
Refactor log colors to Theme.kt

### DIFF
--- a/app/src/main/java/com/grindrplus/manager/ui/ConsoleLogger.kt
+++ b/app/src/main/java/com/grindrplus/manager/ui/ConsoleLogger.kt
@@ -26,6 +26,11 @@ import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.ui.draw.clip
 import androidx.core.content.ContextCompat.getSystemService
+import com.grindrplus.manager.ui.theme.LogDebug
+import com.grindrplus.manager.ui.theme.LogError
+import com.grindrplus.manager.ui.theme.LogSuccess
+import com.grindrplus.manager.ui.theme.LogVerbose
+import com.grindrplus.manager.ui.theme.LogWarning
 import com.grindrplus.manager.utils.uploadAndShare
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -171,12 +176,11 @@ fun ConsoleOutput(
 @Composable
 internal fun LogEntryItem(entry: LogEntry) {
     val logColor = when (entry.type) {
-        // TODO: Move to Theme.kt
-        LogType.SUCCESS -> Color(0xFF4CAF50)
-        LogType.WARNING -> Color(0xFFFFC107)
-        LogType.ERROR -> Color(0xFFE91E63)
-        LogType.DEBUG -> Color(0xFF9C27B0)
-        LogType.VERBOSE -> Color(0xFF757575)
+        LogType.SUCCESS -> LogSuccess
+        LogType.WARNING -> LogWarning
+        LogType.ERROR -> LogError
+        LogType.DEBUG -> LogDebug
+        LogType.VERBOSE -> LogVerbose
         LogType.INFO -> MaterialTheme.colorScheme.onSurfaceVariant
     }
 

--- a/app/src/main/java/com/grindrplus/manager/ui/theme/Theme.kt
+++ b/app/src/main/java/com/grindrplus/manager/ui/theme/Theme.kt
@@ -19,6 +19,12 @@ import androidx.core.view.WindowCompat
 val GrindrYellow = Color(0xFFFFCC00)
 val GrindrDarkYellow = Color(0xFFA38300)
 
+val LogSuccess = Color(0xFF4CAF50)
+val LogWarning = Color(0xFFFFC107)
+val LogError = Color(0xFFE91E63)
+val LogDebug = Color(0xFF9C27B0)
+val LogVerbose = Color(0xFF757575)
+
 private val LightColorScheme = lightColorScheme(
     primary = GrindrYellow,
     onPrimary = Color(0xFF000000),


### PR DESCRIPTION
Moved hardcoded log colors from `ConsoleLogger.kt` to `Theme.kt` to centralize theming and remove TODOs.
Defined `LogSuccess`, `LogWarning`, `LogError`, `LogDebug`, and `LogVerbose` in `Theme.kt`.

---
*PR created automatically by Jules for task [15379731077819715581](https://jules.google.com/task/15379731077819715581) started by @terenzif*