### PR TITLE
⚡ Fix N+1 query in UnlimitedAlbums by batch fetching content

### DIFF
--- a/app/src/main/java/com/grindrplus/hooks/UnlimitedAlbums.kt
+++ b/app/src/main/java/com/grindrplus/hooks/UnlimitedAlbums.kt
@@ -395,9 +395,15 @@ class UnlimitedAlbums : Hook("Unlimited albums", "Allow to be able to view unlim
                     GrindrPlus.database.withTransaction {
                         val dao = GrindrPlus.database.albumDao()
                         val dbAlbums = dao.getAlbums()
+                        val albumIds = dbAlbums.map { it.id }
+                        val allContent =
+                            if (albumIds.isNotEmpty()) dao.getAlbumContents(albumIds)
+                            else emptyList()
+                        val contentMap = allContent.groupBy { it.albumId }
+
                         dbAlbums.mapNotNull {
                             try {
-                                val dbContent = dao.getAlbumContent(it.id)
+                                val dbContent = contentMap[it.id] ?: emptyList()
                                 it.toGrindrAlbum(dbContent)
                             } catch (e: Exception) {
                                 loge("Error converting album ${it.id}: ${e.message}")
@@ -461,9 +467,15 @@ class UnlimitedAlbums : Hook("Unlimited albums", "Allow to be able to view unlim
                     GrindrPlus.database.withTransaction {
                         val dao = GrindrPlus.database.albumDao()
                         val dbAlbums = dao.getAlbums()
+                        val albumIds = dbAlbums.map { it.id }
+                        val allContent =
+                            if (albumIds.isNotEmpty()) dao.getAlbumContents(albumIds)
+                            else emptyList()
+                        val contentMap = allContent.groupBy { it.albumId }
+
                         dbAlbums.mapNotNull {
                             try {
-                                val dbContent = dao.getAlbumContent(it.id)
+                                val dbContent = contentMap[it.id] ?: emptyList()
                                 if (dbContent.isNotEmpty()) {
                                     it.toGrindrAlbumBrief(dbContent.first())
                                 } else {
@@ -535,9 +547,15 @@ class UnlimitedAlbums : Hook("Unlimited albums", "Allow to be able to view unlim
                     GrindrPlus.database.withTransaction {
                         val dao = GrindrPlus.database.albumDao()
                         val dbAlbums = dao.getAlbums(profileId)
+                        val albumIds = dbAlbums.map { it.id }
+                        val allContent =
+                            if (albumIds.isNotEmpty()) dao.getAlbumContents(albumIds)
+                            else emptyList()
+                        val contentMap = allContent.groupBy { it.albumId }
+
                         dbAlbums.mapNotNull {
                             try {
-                                val dbContent = dao.getAlbumContent(it.id)
+                                val dbContent = contentMap[it.id] ?: emptyList()
                                 if (dbContent.isNotEmpty()) {
                                     it.toGrindrAlbumBrief(dbContent.first())
                                 } else {

--- a/app/src/main/java/com/grindrplus/persistence/dao/AlbumDao.kt
+++ b/app/src/main/java/com/grindrplus/persistence/dao/AlbumDao.kt
@@ -65,6 +65,14 @@ interface AlbumDao {
     suspend fun getAlbumContent(albumId: Long): List<AlbumContentEntity>
 
     /**
+     * Gets all album content for a list of albums
+     * @param albumIds The list of album IDs
+     * @return List of album content entities
+     */
+    @Query("SELECT * FROM AlbumContentEntity WHERE albumId IN (:albumIds)")
+    suspend fun getAlbumContents(albumIds: List<Long>): List<AlbumContentEntity>
+
+    /**
      * Upserts an album content entity
      * @param dbAlbumContent The album content entity to upsert
      */


### PR DESCRIPTION
Batch fetch album contents to resolve N+1 query issue in `UnlimitedAlbums.kt`.

### Changes
- Added `getAlbumContents(albumIds: List<Long>)` to `AlbumDao`.
- Updated `UnlimitedAlbums.kt` to collect album IDs, fetch all contents at once, and map them in memory.

### Impact
- Replaced N+1 query pattern with batch fetching.
- Improved database performance for album list retrieval.

---
*PR created automatically by Jules for task [15668640993055691250](https://jules.google.com/task/15668640993055691250) started by @terenzif*