### PR TITLE
🔒 Fix SQL injection in list_table command

### DIFF
--- a/app/src/main/java/com/grindrplus/commands/Database.kt
+++ b/app/src/main/java/com/grindrplus/commands/Database.kt
@@ -72,6 +72,7 @@ class Database(
 
         val tableName = args[0]
         try {
+            // Check if table exists to prevent SQL injection
             if (!DatabaseHelper.getTables().contains(tableName)) {
                 GrindrPlus.showToast(Toast.LENGTH_LONG, "Table '$tableName' does not exist.")
                 return

--- a/app/src/main/java/com/grindrplus/commands/Database.kt
+++ b/app/src/main/java/com/grindrplus/commands/Database.kt
@@ -16,8 +16,7 @@ class Database(
     @Command("list_tables", aliases = ["lts"], help = "List all tables in the database")
     fun listTables(args: List<String>) {
         try {
-            val query = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"
-            val tables = DatabaseHelper.query(query).map { it["name"].toString() }
+            val tables = DatabaseHelper.getTables()
 
             GrindrPlus.runOnMainThreadWithCurrentActivity { activity ->
                 val dialogView = LinearLayout(activity).apply {
@@ -73,6 +72,11 @@ class Database(
 
         val tableName = args[0]
         try {
+            if (!DatabaseHelper.getTables().contains(tableName)) {
+                GrindrPlus.showToast(Toast.LENGTH_LONG, "Table '$tableName' does not exist.")
+                return
+            }
+
             val query = "SELECT * FROM $tableName;"
             val rows = DatabaseHelper.query(query)
 

--- a/app/src/main/java/com/grindrplus/core/DatabaseHelper.kt
+++ b/app/src/main/java/com/grindrplus/core/DatabaseHelper.kt
@@ -74,6 +74,11 @@ object DatabaseHelper {
         return rowsDeleted
     }
 
+    fun getTables(): List<String> {
+        val query = "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name;"
+        return query(query).map { it["name"].toString() }
+    }
+
     fun execute(sql: String) {
         val database = getDatabase()
         database.execSQL(sql)


### PR DESCRIPTION
This PR fixes a SQL injection vulnerability in the `list_table` command.

**Vulnerability:**
The `list_table` command took user input (`args[0]`) and directly interpolated it into a SQL query string: `"SELECT * FROM $tableName;"`. This allowed an attacker to execute arbitrary SQL commands.

**Fix:**
1.  Added `getTables()` to `DatabaseHelper` which returns a list of valid table names by querying `sqlite_master`.
2.  In `list_table` command, before executing the query, we now check if the provided `tableName` exists in the list returned by `getTables()`.
3.  If the table does not exist (or the input is malicious), the command aborts and shows an error message.
4.  Also refactored `list_tables` to use the new `getTables()` method for cleaner code.

**Verification:**
- Verified that `DatabaseHelper.getTables()` correctly queries the schema.
- Verified that `Database.listTable` correctly checks for table existence.
- Successfully built the project with `./gradlew assembleDebug`.

---
*PR created automatically by Jules for task [15246238509747961090](https://jules.google.com/task/15246238509747961090) started by @terenzif*