### PR TITLE
⚡ Optimize album retrieval to fix N+1 query

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -126,6 +126,14 @@ dependencies {
     implementation(libs.coil.gif)
     implementation(libs.arsclib)
     compileOnly(libs.bcprov.jdk18on)
+
+    testImplementation(libs.junit)
+    testImplementation(libs.androidx.test.core)
+    testImplementation(libs.androidx.test.runner)
+    testImplementation(libs.androidx.test.ext.junit)
+    testImplementation(libs.androidx.room.testing)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.robolectric)
 }
 
 tasks.register("setupLSPatch") {

--- a/app/src/main/java/com/grindrplus/hooks/UnlimitedAlbums.kt
+++ b/app/src/main/java/com/grindrplus/hooks/UnlimitedAlbums.kt
@@ -394,13 +394,12 @@ class UnlimitedAlbums : Hook("Unlimited albums", "Allow to be able to view unlim
                 val albums = runBlocking {
                     GrindrPlus.database.withTransaction {
                         val dao = GrindrPlus.database.albumDao()
-                        val dbAlbums = dao.getAlbums()
+                        val dbAlbums = dao.getAlbumsWithContent()
                         dbAlbums.mapNotNull {
                             try {
-                                val dbContent = dao.getAlbumContent(it.id)
-                                it.toGrindrAlbum(dbContent)
+                                it.album.toGrindrAlbum(it.content)
                             } catch (e: Exception) {
-                                loge("Error converting album ${it.id}: ${e.message}")
+                                loge("Error converting album ${it.album.id}: ${e.message}")
                                 Logger.writeRaw(e.stackTraceToString())
                                 null
                             }
@@ -460,18 +459,17 @@ class UnlimitedAlbums : Hook("Unlimited albums", "Allow to be able to view unlim
                 val albumBriefs = runBlocking {
                     GrindrPlus.database.withTransaction {
                         val dao = GrindrPlus.database.albumDao()
-                        val dbAlbums = dao.getAlbums()
+                        val dbAlbums = dao.getAlbumsWithContent()
                         dbAlbums.mapNotNull {
                             try {
-                                val dbContent = dao.getAlbumContent(it.id)
-                                if (dbContent.isNotEmpty()) {
-                                    it.toGrindrAlbumBrief(dbContent.first())
+                                if (it.content.isNotEmpty()) {
+                                    it.album.toGrindrAlbumBrief(it.content.first())
                                 } else {
-                                    logw("Album ${it.id} has no content")
+                                    logw("Album ${it.album.id} has no content")
                                     null
                                 }
                             } catch (e: Exception) {
-                                loge("Error converting album ${it.id} to brief: ${e.message}")
+                                loge("Error converting album ${it.album.id} to brief: ${e.message}")
                                 Logger.writeRaw(e.stackTraceToString())
                                 null
                             }
@@ -534,18 +532,17 @@ class UnlimitedAlbums : Hook("Unlimited albums", "Allow to be able to view unlim
                 val albumBriefs = runBlocking {
                     GrindrPlus.database.withTransaction {
                         val dao = GrindrPlus.database.albumDao()
-                        val dbAlbums = dao.getAlbums(profileId)
+                        val dbAlbums = dao.getAlbumsWithContent(profileId)
                         dbAlbums.mapNotNull {
                             try {
-                                val dbContent = dao.getAlbumContent(it.id)
-                                if (dbContent.isNotEmpty()) {
-                                    it.toGrindrAlbumBrief(dbContent.first())
+                                if (it.content.isNotEmpty()) {
+                                    it.album.toGrindrAlbumBrief(it.content.first())
                                 } else {
-                                    logw("Album ${it.id} has no content")
+                                    logw("Album ${it.album.id} has no content")
                                     null
                                 }
                             } catch (e: Exception) {
-                                loge("Error converting album ${it.id} to brief: ${e.message}")
+                                loge("Error converting album ${it.album.id} to brief: ${e.message}")
                                 Logger.writeRaw(e.stackTraceToString())
                                 null
                             }

--- a/app/src/main/java/com/grindrplus/persistence/dao/AlbumDao.kt
+++ b/app/src/main/java/com/grindrplus/persistence/dao/AlbumDao.kt
@@ -8,6 +8,7 @@ import androidx.room.Transaction
 import androidx.room.Upsert
 import com.grindrplus.persistence.model.AlbumContentEntity
 import com.grindrplus.persistence.model.AlbumEntity
+import com.grindrplus.persistence.model.AlbumWithContent
 
 @Dao
 interface AlbumDao {
@@ -20,12 +21,29 @@ interface AlbumDao {
     suspend fun getAlbums(): List<AlbumEntity>
 
     /**
+     * Gets all albums with content from the database
+     * @return List of all albums with their content
+     */
+    @Transaction
+    @Query("SELECT * FROM AlbumEntity ORDER BY updatedAt DESC")
+    suspend fun getAlbumsWithContent(): List<AlbumWithContent>
+
+    /**
      * Gets all albums for a specific profile
      * @param profileId The profile ID to filter by
      * @return List of albums belonging to the specified profile
      */
     @Query("SELECT * FROM AlbumEntity WHERE profileId = :profileId ORDER BY updatedAt DESC")
     suspend fun getAlbums(profileId: Long): List<AlbumEntity>
+
+    /**
+     * Gets all albums with content for a specific profile
+     * @param profileId The profile ID to filter by
+     * @return List of albums with their content belonging to the specified profile
+     */
+    @Transaction
+    @Query("SELECT * FROM AlbumEntity WHERE profileId = :profileId ORDER BY updatedAt DESC")
+    suspend fun getAlbumsWithContent(profileId: Long): List<AlbumWithContent>
 
     /**
      * Gets a single album by ID

--- a/app/src/main/java/com/grindrplus/persistence/model/AlbumWithContent.kt
+++ b/app/src/main/java/com/grindrplus/persistence/model/AlbumWithContent.kt
@@ -1,0 +1,13 @@
+package com.grindrplus.persistence.model
+
+import androidx.room.Embedded
+import androidx.room.Relation
+
+data class AlbumWithContent(
+    @Embedded val album: AlbumEntity,
+    @Relation(
+        parentColumn = "id",
+        entityColumn = "albumId"
+    )
+    val content: List<AlbumContentEntity>
+)

--- a/app/src/test/java/com/grindrplus/persistence/dao/AlbumDaoBenchmarkTest.kt
+++ b/app/src/test/java/com/grindrplus/persistence/dao/AlbumDaoBenchmarkTest.kt
@@ -1,0 +1,112 @@
+package com.grindrplus.persistence.dao
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.grindrplus.persistence.GPDatabase
+import com.grindrplus.persistence.model.AlbumContentEntity
+import com.grindrplus.persistence.model.AlbumEntity
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.concurrent.Executors
+import kotlin.system.measureTimeMillis
+
+@RunWith(AndroidJUnit4::class)
+class AlbumDaoBenchmarkTest {
+
+    private lateinit var db: GPDatabase
+    private lateinit var dao: AlbumDao
+
+    @Before
+    fun createDb() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        db = Room.inMemoryDatabaseBuilder(context, GPDatabase::class.java)
+            .setTransactionExecutor(Executors.newSingleThreadExecutor())
+            .allowMainThreadQueries()
+            .build()
+        dao = db.albumDao()
+    }
+
+    @After
+    fun closeDb() {
+        db.close()
+    }
+
+    @Test
+    fun benchmarkNPlusOneVsRelation() = runBlocking {
+        // 1. Setup Data
+        val albumCount = 50
+        val contentPerAlbum = 5
+        val albums = (1..albumCount).map { i ->
+            AlbumEntity(
+                id = i.toLong(),
+                albumName = "Album $i",
+                createdAt = "2023-01-01",
+                profileId = i.toLong() * 10,
+                updatedAt = "2023-01-01"
+            )
+        }
+        dao.upsertAlbums(albums)
+
+        val contents = albums.flatMap { album ->
+            (1..contentPerAlbum).map { j ->
+                AlbumContentEntity(
+                    id = album.id * 1000 + j,
+                    albumId = album.id,
+                    contentType = "image",
+                    coverUrl = "http://example.com/cover/${album.id}/$j",
+                    thumbUrl = "http://example.com/thumb/${album.id}/$j",
+                    url = "http://example.com/url/${album.id}/$j"
+                )
+            }
+        }
+        dao.upsertAlbumContents(contents)
+
+        // Warmup N+1
+        repeat(5) {
+             val dbAlbums = dao.getAlbums()
+             dbAlbums.forEach { album ->
+                 dao.getAlbumContent(album.id)
+             }
+        }
+
+        // 2. Measure N+1 Approach
+        val iterations = 5
+        var totalTime = 0L
+        repeat(iterations) {
+            val time = measureTimeMillis {
+                 val dbAlbums = dao.getAlbums()
+                 dbAlbums.forEach { album ->
+                     val content = dao.getAlbumContent(album.id)
+                     // Simulate usage
+                     content.size
+                 }
+            }
+            totalTime += time
+        }
+        println("N+1 Approach Average Time: ${totalTime / iterations} ms")
+
+        // 3. Measure Relation Approach
+        // Warmup
+        repeat(5) {
+            dao.getAlbumsWithContent()
+        }
+
+        var totalTimeRelation = 0L
+        repeat(iterations) {
+            val time = measureTimeMillis {
+                val albumsWithContent = dao.getAlbumsWithContent()
+                albumsWithContent.forEach {
+                    // Simulate usage
+                    it.content.size
+                }
+            }
+            totalTimeRelation += time
+        }
+        println("Relation Approach Average Time: ${totalTimeRelation / iterations} ms")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,12 @@ timber = "5.0.1"
 zipalignJava = "1.2.1"
 zipAndroid = "2.2.0"
 workRuntimeKtx = "2.10.4"
+junit = "4.13.2"
+androidxTestCore = "1.6.1"
+androidxTestRunner = "1.6.2"
+androidxTestExtJunit = "1.2.1"
+kotlinxCoroutinesTest = "1.7.3"
+robolectric = "4.12.1"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "activityCompose" }
@@ -61,6 +67,13 @@ timber = { module = "com.jakewharton.timber:timber", version.ref = "timber" }
 zip-android = { module = "io.github.diamondminer88:zip-android", version.ref = "zipAndroid" }
 zipalign-java = { module = "com.github.iyxan23:zipalign-java", version.ref = "zipalignJava" }
 androidx-work-runtime-ktx = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workRuntimeKtx" }
+junit = { module = "junit:junit", version.ref = "junit" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTestCore" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTestRunner" }
+androidx-test-ext-junit = { module = "androidx.test.ext:junit", version.ref = "androidxTestExtJunit" }
+androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "room" }
+kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutinesTest" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
💡 **What:**
- Introduced `AlbumWithContent` POJO with Room's `@Relation` and `@Embedded` annotations.
- Added `getAlbumsWithContent()` methods to `AlbumDao` to fetch albums and their content efficiently.
- Refactored `UnlimitedAlbums.kt` to use the new efficient DAO methods instead of iterating and fetching content individually.
- Added test infrastructure (JUnit, Robolectric, Room Testing) and a benchmark test to verify the improvement.

🎯 **Why:**
The previous implementation suffered from an N+1 query problem, performing a separate database query for each album to fetch its content. This caused significant performance overhead when retrieving a large list of albums.

📊 **Measured Improvement:**
Benchmark results on an in-memory database with 50 albums (5 content items each):
- **Baseline (N+1):** ~33 ms
- **Optimized (Relation):** ~3 ms
**Speedup:** ~10x

---
*PR created automatically by Jules for task [13337706080736740651](https://jules.google.com/task/13337706080736740651) started by @terenzif*