### PR TITLE
Resolve TODO in EnableUnlimited and fix resource ID bug

### DIFF
--- a/app/src/main/java/com/grindrplus/hooks/EnableUnlimited.kt
+++ b/app/src/main/java/com/grindrplus/hooks/EnableUnlimited.kt
@@ -34,7 +34,7 @@ class EnableUnlimited : Hook(
     private val viewsToHide = mapOf(
         "com.grindrapp.android.ui.tagsearch.ProfileTagCascadeFragment\$b" to listOf("upsell_bottom_bar"), // search for 'bind(Landroid/view/View;)Lcom/grindrapp/android/databinding/ProfileTagCascadeFragmentBinding;'
         "com.grindrapp.android.ui.browse.CascadeFragment\$b" to listOf("upsell_bottom_bar", "shuffle_top_bar", "floating_rating_banner", "micros_fab", "right_now_progress_compose_view"), // search for '"bind(Landroid/view/View;)Lcom/grindrapp/android/databinding/FragmentBrowseCascadeBinding;"'
-        "com.grindrapp.android.ui.home.HomeActivity\$g" to listOf("persistentAdBannerContainer"), // search for 'ViewBindings.findChildViewById(inflate, R.id.activity_home_content);'
+        "com.grindrapp.android.ui.home.HomeActivity\$g" to listOf("persistent_banner_ad_container", "persistent_banner_ad_compose_view"), // search for 'ViewBindings.findChildViewById(inflate, R.id.activity_home_content);'
         "com.grindrapp.android.ui.drawer.DrawerProfileFragment\$e" to listOf("plans_title", "store_in_profile_drawer_card", "sideDrawerBoostContainer", "drawer_profile_offer_card"), // search for '"bind(Landroid/view/View;)Lcom/grindrapp/android/databinding/DrawerProfileBinding;"'
         "com.grindrapp.android.radar.presentation.ui.RadarFragment\$c" to listOf("micros_fab", "right_now_fabs_container") // search for 'bind(Landroid/view/View;)Lcom/grindrapp/android/databinding/FragmentRadarBinding;'
     )
@@ -116,8 +116,7 @@ class EnableUnlimited : Hook(
         findClass(persistentAdBannerContainer).hook("a", HookStage.BEFORE) { param ->
             if (param.args().isNotEmpty()) {
                 val rootView = param.arg<View>(0)
-				// TODO validate change from persistent_banner_ad_container to persistent_banner_ad_compose_view
-                hideViews(rootView, listOf("persistent_banner_ad_compose_view"))
+                hideViews(rootView, listOf("persistent_banner_ad_container", "persistent_banner_ad_compose_view"))
             }
         }
 


### PR DESCRIPTION
This change addresses a code health issue in `EnableUnlimited.kt`. 

**Changes:**
1.  **Resolved TODO:** Updated the hook for the persistent ad banner container to attempt hiding views with both `persistent_banner_ad_container` and `persistent_banner_ad_compose_view` IDs. This ensures the hook remains effective if the target app uses either ID, removing the need for the TODO comment.
2.  **Fixed Bug:** Identified and corrected an entry in the `viewsToHide` map for `HomeActivity`. The previous code incorrectly used the variable name `"persistentAdBannerContainer"` as a resource ID string. This has been replaced with the actual resource ID strings: `persistent_banner_ad_container` and `persistent_banner_ad_compose_view`.

**Verification:**
*   Ran `./gradlew compileDebugKotlin` to verify compilation.
*   Ran `./gradlew :app:testDebugUnitTest` to ensure no regressions in unit tests.
*   Verified the logic handles missing views gracefully (via existing try-catch block in `hideViews`).

---
*PR created automatically by Jules for task [11001471292324181938](https://jules.google.com/task/11001471292324181938) started by @terenzif*