### PR TITLE
🔒 Fix insecure user certificate trust configuration

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,9 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-	<base-config>
-		<trust-anchors>
-			<certificates src="user"/>
-			<certificates src="system"/>
-		</trust-anchors>
-	</base-config>
+    <base-config>
+        <trust-anchors>
+            <certificates src="system"/>
+        </trust-anchors>
+    </base-config>
+    <debug-overrides>
+        <trust-anchors>
+            <certificates src="user"/>
+        </trust-anchors>
+    </debug-overrides>
 </network-security-config>


### PR DESCRIPTION
## 🔒 Security Vulnerability Fix

### 🎯 What
The `network_security_config.xml` previously allowed user-installed certificates to be trusted in the base configuration, which applies to all build types (including release).

### ⚠️ Risk
This configuration creates a significant security vulnerability by allowing Man-in-the-Middle (MITM) attacks if a user installs a malicious certificate on their device. This bypasses certificate pinning protections intended for production builds.

### 🛡️ Solution
Moved the trust for user certificates (`<certificates src="user"/>`) from `<base-config>` to `<debug-overrides>`.
-   **Release Builds:** Only system certificates are trusted by default.
-   **Debug Builds:** User certificates are trusted alongside system certificates, maintaining developer workflow (e.g., using Charles Proxy) without compromising production security.

### Verification
-   Verified the XML structure programmatically to ensure `user` certs are removed from `base-config` and present in `debug-overrides`.
-   Verified resource processing via `./gradlew processDebugResources`.

---
*PR created automatically by Jules for task [14662262500610886868](https://jules.google.com/task/14662262500610886868) started by @terenzif*