### PR TITLE
🔒 fix: remove sensitive data logging from hooks

### DIFF
--- a/app/src/main/java/com/grindrplus/hooks/EnableUnlimited.kt
+++ b/app/src/main/java/com/grindrplus/hooks/EnableUnlimited.kt
@@ -44,7 +44,6 @@ class EnableUnlimited : Hook(
         userSessionClass.hook( // rolesUpdated()
 			"W", HookStage.BEFORE // search for 'Intrinsics.checkNotNullParameter(roles, "roles");' in userSession
 		) { param ->
-			val roles = param.arg(0) as List<String>
 			val allRoles = listOf(
 				"Plus",
 				"Xtra",
@@ -56,7 +55,7 @@ class EnableUnlimited : Hook(
 				"Free_Premium"
 			)
 
-			logi("received roles: $roles, replacing with $allRoles")
+			logd("Updating user roles to enable unlimited features")
 
 			param.setArg(0, allRoles)
 		}

--- a/app/src/main/java/com/grindrplus/hooks/ExpiringMedia.kt
+++ b/app/src/main/java/com/grindrplus/hooks/ExpiringMedia.kt
@@ -101,7 +101,7 @@ class ExpiringMedia : Hook(
         if (!originalUrl.isNullOrEmpty() && !originalUrl.startsWith("file://")) {
             coroutineScope.launch {
                 try {
-                    logd("Downloading $mediaTypeStr from URL: ${originalUrl.take(50)}...")
+                    logd("Downloading $mediaTypeStr")
 
                     MediaUtils.downloadMedia(originalUrl).fold(
                         onSuccess = { mediaData ->
@@ -133,7 +133,7 @@ class ExpiringMedia : Hook(
 
         MediaUtils.saveMedia(mediaId, mediaData, mediaType, fileExtension).fold(
             onSuccess = { filePath ->
-                logi("Saved $mediaTypeStr permanently for mediaId: $mediaId")
+                logi("Saved $mediaTypeStr permanently")
                 filePathCache[mediaId] = filePath
 
                 withContext(Dispatchers.Main) {

--- a/app/src/main/java/com/grindrplus/hooks/LocalSavedPhrases.kt
+++ b/app/src/main/java/com/grindrplus/hooks/LocalSavedPhrases.kt
@@ -74,12 +74,12 @@ class LocalSavedPhrases : Hook(
             when {
                 method.isPOST("v3/me/prefs/phrases") -> {
                     val phrase = getObjectField(args[0], "phrase") as String
-                    logi("Adding new local phrase: \"$phrase\"")
+                    logi("Adding new local phrase")
 
                     runBlocking {
                         val index = getCurrentPhraseIndex() + 1
                         addPhrase(index, phrase, 0, System.currentTimeMillis())
-                        logs("Phrase saved locally with ID: $index")
+                        logs("Phrase saved locally")
 
                         val response = savedPhraseConstructor?.newInstance(index.toString())
                         createSuccess.newInstance(response)
@@ -88,19 +88,19 @@ class LocalSavedPhrases : Hook(
 
                 method.isDELETE("v3/me/prefs/phrases/{id}") -> {
                     val id = args[0] as? String ?: "unknown"
-                    logi("Deleting local phrase ID: $id")
+                    logi("Deleting local phrase")
 
                     runBlocking {
                         val index = id.toLongOrNull() ?: getCurrentPhraseIndex()
                         deletePhrase(index)
-                        logs("Deleted local phrase ID: $index")
+                        logs("Deleted local phrase")
                         createSuccess.newInstance(Unit)
                     }
                 }
 
                 method.isPOST("v4/phrases/frequency/{id}") -> {
                     val id = args[0] as? String ?: "0"
-                    logd("Incrementing usage frequency for ID: $id")
+                    logd("Incrementing phrase usage frequency")
 
                     runBlocking {
                         val index = id.toLongOrNull() ?: 0L


### PR DESCRIPTION
This PR addresses a security vulnerability where sensitive user data was being logged in several hooks. 

Specifically:
- In `LocalSavedPhrases.kt`, user-provided chat phrases and their database IDs are no longer logged.
- In `EnableUnlimited.kt`, user subscription roles are no longer logged, and an unused variable was removed.
- In `ExpiringMedia.kt`, media URLs (which might contain tokens) and media IDs are no longer logged.

These changes ensure that private information is not leaked to Logcat or persistent log files on the device.

---
*PR created automatically by Jules for task [1113755068273633359](https://jules.google.com/task/1113755068273633359) started by @terenzif*