### PR TITLE
🔒 Fix Open Redirect in ForceStartActivity

### DIFF
--- a/app/src/main/java/com/grindrplus/bridge/ForceStartActivity.kt
+++ b/app/src/main/java/com/grindrplus/bridge/ForceStartActivity.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
 import com.grindrplus.BuildConfig
+import com.grindrplus.core.Constants
 import com.grindrplus.core.LogSource
 import com.grindrplus.core.Logger
 import timber.log.Timber
@@ -29,11 +30,15 @@ class ForceStartActivity : Activity() {
 
             val pkg = intent.getStringExtra("pkg")
             if (pkg != null) {
-                val launchIntent = packageManager.getLaunchIntentForPackage(pkg)
-                if (launchIntent != null) {
-                    launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    startActivity(launchIntent)
-                    Timber.tag(TAG).d("Launched package: $pkg")
+                if (pkg == Constants.GRINDR_PACKAGE_NAME) {
+                    val launchIntent = packageManager.getLaunchIntentForPackage(pkg)
+                    if (launchIntent != null) {
+                        launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        startActivity(launchIntent)
+                        Timber.tag(TAG).d("Launched package: $pkg")
+                    }
+                } else {
+                    Timber.tag(TAG).w("Unauthorized package launch attempt: $pkg")
                 }
             }
 


### PR DESCRIPTION
This PR addresses a security vulnerability in `ForceStartActivity` where the `pkg` intent extra could be used to launch arbitrary packages, creating an open redirect/proxy issue.

**Changes:**
- Added strict validation for the `pkg` intent extra.
- Only allows launching `com.grindrapp.android` (Grindr).
- Logs a warning if an unauthorized package is requested.

**Verification:**
- Verified that the code compiles successfully (`./gradlew compileDebugKotlin`).
- Ran unit tests (`./gradlew :app:testDebugUnitTest`) to ensure no regressions.
- Confirmed with the user that `com.grindrapp.android` is the only intended target.

---
*PR created automatically by Jules for task [9775848774417488341](https://jules.google.com/task/9775848774417488341) started by @terenzif*