### PR TITLE
🧹 Extract setupLSPatch task to separate script

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,12 +1,3 @@
-import com.android.build.gradle.internal.api.BaseVariantOutputImpl
-import java.net.URI
-import java.net.URL
-import java.io.FileOutputStream
-import java.nio.file.Files
-import java.nio.file.FileSystems
-import java.nio.file.Path
-import java.util.Comparator
-
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.googleKsp)
@@ -140,72 +131,7 @@ dependencies {
     testImplementation(libs.robolectric)
 }
 
-tasks.register("setupLSPatch") {
-    doLast {
-        val tempDir = layout.buildDirectory.get().asFile.resolve("lspatch_temp")
-        tempDir.mkdirs()
-
-        val nightlyLink = "https://nightly.link/JingMatrix/LSPatch/workflows/main/master?preview"
-        // Simple download of the nightly page to find the URL
-        val nightlyContent = URI(nightlyLink).toURL().readText()
-        val jarUrl = Regex("https:\\/\\/nightly\\.link\\/JingMatrix\\/LSPatch\\/workflows\\/main\\/master\\/lspatch-debug-[^.]+\\.zip").find(
-            nightlyContent
-        )!!.value
-
-        val zipFile = tempDir.resolve("lspatch.zip")
-        
-        // Download zip
-        URI(jarUrl).toURL().openStream().use { input ->
-            FileOutputStream(zipFile).use { output ->
-                input.copyTo(output)
-            }
-        }
-
-        // Unzip
-        copy {
-            from(zipTree(zipFile))
-            into(tempDir)
-        }
-
-        val jarFile = tempDir.listFiles()?.find { it.name.contains("jar-") && it.extension == "jar" }
-            ?: throw GradleException("LSPatch jar not found in zip")
-
-        // Extract assets/lspatch/so* to src/main/
-        copy {
-            from(zipTree(jarFile)) {
-                include("assets/lspatch/so*")
-            }
-            into(project.projectDir.resolve("src/main/"))
-        }
-
-        // Move/Copy jar to libs/lspatch.jar
-        val targetLib = project.projectDir.resolve("libs/lspatch.jar")
-        targetLib.parentFile.mkdirs()
-        jarFile.copyTo(targetLib, overwrite = true)
-
-        // Delete specific classes/packages from the jar using ZipFileSystem
-        val jarUri = URI.create("jar:" + targetLib.toURI())
-        val env = mapOf("create" to "false")
-        
-        FileSystems.newFileSystem(jarUri, env).use { fs ->
-            // Delete com/google/common/util/concurrent/ListenableFuture.class
-            val p1 = fs.getPath("com/google/common/util/concurrent/ListenableFuture.class")
-            if (Files.exists(p1)) {
-                Files.delete(p1)
-            }
-
-            // Delete com/google/errorprone/annotations/*
-            val p2 = fs.getPath("com/google/errorprone/annotations")
-            if (Files.exists(p2)) {
-                 Files.walk(p2)
-                    .sorted(Comparator.reverseOrder())
-                    .forEach { p ->
-                         Files.delete(p)
-                    }
-            }
-        }
-    }
-}
+apply(from = rootProject.file("scripts/setup_lspatch.gradle.kts"))
 
 fun getGitCommitHash(): String? {
     return try {

--- a/scripts/setup_lspatch.gradle.kts
+++ b/scripts/setup_lspatch.gradle.kts
@@ -1,0 +1,74 @@
+import java.net.URI
+import java.net.URL
+import java.io.FileOutputStream
+import java.nio.file.Files
+import java.nio.file.FileSystems
+import java.nio.file.Path
+import java.util.Comparator
+
+tasks.register("setupLSPatch") {
+    doLast {
+        val tempDir = layout.buildDirectory.get().asFile.resolve("lspatch_temp")
+        tempDir.mkdirs()
+
+        val nightlyLink = "https://nightly.link/JingMatrix/LSPatch/workflows/main/master?preview"
+        // Simple download of the nightly page to find the URL
+        val nightlyContent = URI(nightlyLink).toURL().readText()
+        val jarUrl = Regex("https:\\/\\/nightly\\.link\\/JingMatrix\\/LSPatch\\/workflows\\/main\\/master\\/lspatch-debug-[^.]+\\.zip").find(
+            nightlyContent
+        )!!.value
+
+        val zipFile = tempDir.resolve("lspatch.zip")
+
+        // Download zip
+        URI(jarUrl).toURL().openStream().use { input ->
+            FileOutputStream(zipFile).use { output ->
+                input.copyTo(output)
+            }
+        }
+
+        // Unzip
+        copy {
+            from(zipTree(zipFile))
+            into(tempDir)
+        }
+
+        val jarFile = tempDir.listFiles()?.find { it.name.contains("jar-") && it.extension == "jar" }
+            ?: throw GradleException("LSPatch jar not found in zip")
+
+        // Extract assets/lspatch/so* to src/main/
+        copy {
+            from(zipTree(jarFile)) {
+                include("assets/lspatch/so*")
+            }
+            into(project.projectDir.resolve("src/main/"))
+        }
+
+        // Move/Copy jar to libs/lspatch.jar
+        val targetLib = project.projectDir.resolve("libs/lspatch.jar")
+        targetLib.parentFile.mkdirs()
+        jarFile.copyTo(targetLib, overwrite = true)
+
+        // Delete specific classes/packages from the jar using ZipFileSystem
+        val jarUri = URI.create("jar:" + targetLib.toURI())
+        val env = mapOf("create" to "false")
+
+        FileSystems.newFileSystem(jarUri, env).use { fs ->
+            // Delete com/google/common/util/concurrent/ListenableFuture.class
+            val p1 = fs.getPath("com/google/common/util/concurrent/ListenableFuture.class")
+            if (Files.exists(p1)) {
+                Files.delete(p1)
+            }
+
+            // Delete com/google/errorprone/annotations/*
+            val p2 = fs.getPath("com/google/errorprone/annotations")
+            if (Files.exists(p2)) {
+                 Files.walk(p2)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach { p ->
+                         Files.delete(p)
+                    }
+            }
+        }
+    }
+}


### PR DESCRIPTION
🎯 **What:** Extracted the `setupLSPatch` task logic and its imports from `app/build.gradle.kts` into a new script `scripts/setup_lspatch.gradle.kts`.
💡 **Why:** This improves the maintainability and readability of the main build file by moving complex, non-standard build logic into a dedicated file.
✅ **Verification:** Verified that the task is still registered using `./gradlew tasks` and that the build configuration is valid using `./gradlew help`.
✨ **Result:** A cleaner `app/build.gradle.kts` and a modular `setupLSPatch` script.

---
*PR created automatically by Jules for task [6996857952562081945](https://jules.google.com/task/6996857952562081945) started by @terenzif*