### PR TITLE
🧹 Remove dead code in ProfileDetails hook

### DIFF
--- a/app/src/main/java/com/grindrplus/hooks/ProfileDetails.kt
+++ b/app/src/main/java/com/grindrplus/hooks/ProfileDetails.kt
@@ -168,7 +168,6 @@ class ProfileDetails : Hook(
 
         findClass(distanceUtils).hook("c", HookStage.AFTER) { param ->
             val distance = param.arg<Double>(0)
-            // val isAbbreviated = param.arg<Boolean>(1)
             val isFeet = param.arg<Boolean>(2)
 
             param.setResult(


### PR DESCRIPTION
Removed a commented-out line of code in `ProfileDetails.kt`. This was identified as dead code and its removal improves readability.Verified that the variable was not used elsewhere in the block.

---
*PR created automatically by Jules for task [13918303148208838429](https://jules.google.com/task/13918303148208838429) started by @terenzif*