### PR TITLE
Refactor: Resolve TODO in CloneGrindrStep by documenting fillVoid usage

### DIFF
--- a/app/src/main/java/com/grindrplus/manager/installation/steps/CloneGrindrStep.kt
+++ b/app/src/main/java/com/grindrplus/manager/installation/steps/CloneGrindrStep.kt
@@ -50,10 +50,12 @@ class CloneGrindrStep(
                 }
 
                 print("Deleting old AndroidManifest.xml in ${file.name}")
+                // fillVoid = true: avoids rewriting the entire file. The voids
+                // will be removed by zipalign in SignClonedGrindrApk.
                 zip.deleteEntry(
                     "AndroidManifest.xml",
-                    /* fillVoid = */ true //TODO: maybe
-                ) // Preserve alignment in libs apk
+                    /* fillVoid = */ true
+                )
 
                 print("Adding patched AndroidManifest.xml in ${file.name}")
                 zip.writeEntry("AndroidManifest.xml", patchedManifestBytes)


### PR DESCRIPTION
This PR resolves a TODO in `CloneGrindrStep.kt` regarding the `fillVoid` parameter in `zip.deleteEntry`.

**What:**
- The `//TODO: maybe` comment next to `fillVoid = true` was removed.
- A comment block was added to explain that `fillVoid = true` is intentional for performance reasons (avoids full file rewrite).
- The comment also clarifies that the subsequent `SignClonedGrindrApk` step performs `zipalign`, which handles any fragmentation/voids introduced by this operation.

**Why:**
- To improve code clarity and remove ambiguity about the `fillVoid` parameter usage.
- To document the dependency between `CloneGrindrStep` and `SignClonedGrindrApk` regarding zip alignment.

**Verification:**
- Verified that `SignClonedGrindrApk` indeed calls `ZipAlign.alignZip`.
- Compiled the code using `./gradlew compileDebugKotlin` to ensure no syntax errors were introduced.
- Verified the file content manually.

---
*PR created automatically by Jules for task [9910130000653076275](https://jules.google.com/task/9910130000653076275) started by @terenzif*